### PR TITLE
add env variable to assign escape sequence in insert mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # vim.zsh
+
 A simple vim plugin for zsh
+
+## Custom key bindings
+
+A common habit of vim users is to re-map a key sequence to`<Esc>` in insert mode, to avoid having to reach far on the keyboard. You can do the same here by simply assigning a key binding to the env variable `VI_MODE_ESC_INSERT`: for example
+
+```bash
+
+export VI_MODE_ESC_INSERT="jk"
+```
+
+will escape back into normal mode upon pressing `jk`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A common habit of vim users is to re-map a key sequence to`<Esc>` in insert mode
 
 ```bash
 
-export VI_MODE_ESC_INSERT="jk"
+export VI_MODE_ESC_INSERT="jk" && plug "zap-zsh/vim"
 ```
 
-will escape back into normal mode upon pressing `jk`.
+will escape back into normal mode upon pressing `jk`. 

--- a/vim.plugin.zsh
+++ b/vim.plugin.zsh
@@ -34,4 +34,6 @@ bindkey -M viins '^A' beginning-of-line
 bindkey -M viins '^E' end-of-line 
 
 # escape back into normal mode
-[[ -n "${VI_MODE_ESC_INSERT}" ]] && bindkey -M viins "${VI_MODE_ESC_INSERT}" vi-cmd-mode
+if [[ -n "${VI_MODE_ESC_INSERT}" ]] then
+    bindkey -M viins "${VI_MODE_ESC_INSERT}" vi-cmd-mode
+fi

--- a/vim.plugin.zsh
+++ b/vim.plugin.zsh
@@ -1,6 +1,6 @@
 #!/bin/sh
 bindkey -v
-export KEYTIMEOUT=1
+export KEYTIMEOUT=25
 
 if [[ -o menucomplete ]]; then 
   # Use vim keys in tab complete menu:
@@ -32,3 +32,6 @@ preexec() { echo -ne '\e[5 q' ;} # Use beam shape cursor for each new prompt.
 # emacs like keybindings
 bindkey -M viins '^A' beginning-of-line 
 bindkey -M viins '^E' end-of-line 
+
+# escape back into normal mode
+[[ -n "${VI_MODE_ESC_INSERT}" ]] && bindkey -M viins "${VI_MODE_ESC_INSERT}" vi-cmd-mode


### PR DESCRIPTION
- expose environment variable for users to assign escape sequence in insert mode
- address https://github.com/zap-zsh/vim/issues/6 