### PR TITLE
Lower key timeout to 1

### DIFF
--- a/vim.plugin.zsh
+++ b/vim.plugin.zsh
@@ -1,6 +1,6 @@
 #!/bin/sh
 bindkey -v
-export KEYTIMEOUT=25
+export KEYTIMEOUT=1
 
 if [[ -o menucomplete ]]; then 
   # Use vim keys in tab complete menu:


### PR DESCRIPTION
Lower key timeout to 1, at 25 it takes over a second when pressing escape in enter mode for it to go to normal mode, making it easy to accidentaly type wrong characters.

If this change isn't acceptable, I'm willing to change to pull request to just note the value in the readme.md so that users who wan't to lower know how to.