### PR TITLE
Make cursor shape configurale

### DIFF
--- a/vim.plugin.zsh
+++ b/vim.plugin.zsh
@@ -2,7 +2,10 @@
 bindkey -v
 export KEYTIMEOUT=25
 
-if [[ -o menucomplete ]]; then 
+VICMD=${VICMD:-'\e[1 q'}  # defaults to block
+VIINS=${VIINS:-'\e[5 q'}  # defaults to beam
+
+if [[ -o menucomplete ]]; then
   # Use vim keys in tab complete menu:
   bindkey -M menuselect '^h' vi-backward-char
   bindkey -M menuselect '^k' vi-up-line-or-history
@@ -16,22 +19,22 @@ bindkey -v '^?' backward-delete-char
 # Change cursor shape for different vi modes.
 function zle-keymap-select () {
     case $KEYMAP in
-        vicmd) echo -ne '\e[1 q';;      # block
-        viins|main) echo -ne '\e[5 q';; # beam
+        vicmd) echo -ne ${VICMD};;      # block
+        viins|main) echo -ne ${VIINS};; # beam
     esac
 }
 zle -N zle-keymap-select
 zle-line-init() {
     zle -K viins # initiate `vi insert` as keymap (can be removed if `bindkey -V` has been set elsewhere)
-    echo -ne "\e[5 q"
+    echo -ne ${VIINS}
 }
 zle -N zle-line-init
-echo -ne '\e[5 q' # Use beam shape cursor on startup.
-preexec() { echo -ne '\e[5 q' ;} # Use beam shape cursor for each new prompt.
+echo -ne ${VIINS} # Use beam shape cursor on startup.
+preexec() { echo -ne ${VIINS} ;} # Use beam shape cursor for each new prompt.
 
 # emacs like keybindings
-bindkey -M viins '^A' beginning-of-line 
-bindkey -M viins '^E' end-of-line 
+bindkey -M viins '^A' beginning-of-line
+bindkey -M viins '^E' end-of-line
 
 # Add text objects for quotes and brackets.
 autoload -Uz select-bracketed select-quoted


### PR DESCRIPTION
**Make the cursor shape configurable via environment variables.**

* Set `VICMD` to set the cursor shape for cmd mode (defaults to beam).
* Set `VIINS` to the the cursor shape for insert mode (defaults to block).

For example,

```zsh
VICMD='\e[5 q'  # beam for command mode
VIINS='\e[1 q'  # block for insert mode
plug zap-zsh/vim
```